### PR TITLE
Fix five correctness bugs in the Advanced_Excel wrapper

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+* text=auto eol=lf
+*.cs text eol=lf
+*.csproj text eol=lf
+*.sln text eol=lf
+*.config text eol=lf
+*.bat text eol=crlf
+*.xlsx binary
+*.xls binary
+*.oap binary
+*.xif binary
+*.ico binary

--- a/Advanced_Excel/Source/NET/Advanced_Excel.cs
+++ b/Advanced_Excel/Source/NET/Advanced_Excel.cs
@@ -676,19 +676,23 @@ namespace OutSystems.NssAdvanced_Excel
         public void MssWorksheet_GetImages(object ssWorksheet, out RLImageRecordList ssImages)
         {
             ssImages = new RLImageRecordList();
-            RCImageRecord Img = new RCImageRecord();
-            ExcelPicture picture = null;
 
             ExcelWorksheet ws = (ExcelWorksheet)ssWorksheet;
 
             var pics = ws.Drawings;
             for (int i = 0; i < pics.Count; i++)
             {
-                Img.ssSTImage.ssName = pics[i].Name;
-                picture = pics[i] as ExcelPicture;
+                ExcelPicture picture = pics[i] as ExcelPicture;
+                if (picture == null)
+                {
+                    continue;
+                }
+
+                RCImageRecord Img = new RCImageRecord();
+                Img.ssSTImage.ssName = picture.Name;
                 Img.ssSTImage.ssContent = Util.ImageToByteArray(picture.Image);
-                Img.ssSTImage.ssColumn = pics[i].From.Column;
-                Img.ssSTImage.ssRow = pics[i].From.Row;
+                Img.ssSTImage.ssColumn = picture.From.Column;
+                Img.ssSTImage.ssRow = picture.From.Row;
                 ssImages.Append(Img);
             }
         } // MssWorksheet_GetImages
@@ -966,7 +970,7 @@ namespace OutSystems.NssAdvanced_Excel
             {
                 if (ssProtectionOptions != null && !string.IsNullOrEmpty(ssProtectionOptions.ssSTProtection.ssPassword))
                 {
-                    ws.Protection.SetPassword(ssPassword);
+                    ws.Protection.SetPassword(ssProtectionOptions.ssSTProtection.ssPassword);
                 }
             }
         } // MssWorksheet_Protect
@@ -1119,7 +1123,7 @@ namespace OutSystems.NssAdvanced_Excel
 
             for (int row = 1; row <= nrRows; row++)
             {
-                for (int col = ssStartColumnNumber; col <= ssStartColumnNumber + ssNumberOfColumns; col++)
+                for (int col = ssStartColumnNumber; col < ssStartColumnNumber + ssNumberOfColumns; col++)
                 {
                     if (ws.Cells[row, col].Comment == null)
                     {
@@ -1183,7 +1187,7 @@ namespace OutSystems.NssAdvanced_Excel
 
             for (int col = 1; col <= nrColumns; col++)
             {
-                for (int row = ssStartRowNumber; row <= ssStartRowNumber + ssNumberOfRows; row++)
+                for (int row = ssStartRowNumber; row < ssStartRowNumber + ssNumberOfRows; row++)
                 {
                     if (ws.Cells[row, col].Comment == null)
                     {
@@ -1501,7 +1505,7 @@ namespace OutSystems.NssAdvanced_Excel
                     Util.ApplyConditionalFormattingStyle(t.Style, ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStyle);
                     break;
                 case eExcelConditionalFormattingRuleType.TopPercent:
-                    var tp = ws.ConditionalFormatting.AddBottomPercent(address);
+                    var tp = ws.ConditionalFormatting.AddTopPercent(address);
                     tp.Priority = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssPriority;
                     tp.StopIfTrue = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStopIfTrue;
                     Util.ApplyConditionalFormattingStyle(tp.Style, ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStyle);
@@ -2084,10 +2088,10 @@ namespace OutSystems.NssAdvanced_Excel
                     }
                 }
 
-                ws.Cells[ssRowStart, ssColumnStart].LoadFromDataTable(dt, ssExportHeaders);
-            }
+                ExcelRange range = (ExcelRange)ws.Cells[ssRowStart, ssColumnStart].LoadFromDataTable(dt, ssExportHeaders);
 
-            Util.ApplyFormatToRange(ws.Cells[ssRowStart, ssColumnStart], ssCellFormat);
+                Util.ApplyFormatToRange(range, ssCellFormat);
+            }
         } // MssCell_WriteRangeWithFormat
 
         /// <summary>
@@ -2131,7 +2135,9 @@ namespace OutSystems.NssAdvanced_Excel
         /// <param name="ssWorkbook">The workbook that you want to work with.</param>
         public void MssWorkbook_Open(string ssFileName, byte[] ssBinary_Data, out object ssWorkbook)
         {
-            if (ssBinary_Data.LongLength <= 0 && string.IsNullOrEmpty(ssFileName))
+            bool hasBinaryData = ssBinary_Data != null && ssBinary_Data.LongLength > 0;
+
+            if (!hasBinaryData && string.IsNullOrEmpty(ssFileName))
             {
                 throw new Exception("You need to specify at least one of FileName or Binary_Data");
             }
@@ -2140,14 +2146,17 @@ namespace OutSystems.NssAdvanced_Excel
             if (ssFileName.ToLower().StartsWith("http:") || ssFileName.ToLower().StartsWith("https:"))
             {
                 System.Net.HttpWebRequest request = (HttpWebRequest)WebRequest.Create(ssFileName);
-                HttpWebResponse response = (HttpWebResponse)request.GetResponse();
-                p.Load(response.GetResponseStream());
+                using (HttpWebResponse response = (HttpWebResponse)request.GetResponse())
+                using (Stream responseStream = response.GetResponseStream())
+                {
+                    p.Load(responseStream);
+                }
             }
             else if (!string.IsNullOrEmpty(ssFileName))
             {
                 p.Load(System.IO.File.Open(ssFileName, System.IO.FileMode.OpenOrCreate));
             }
-            else if (ssBinary_Data.LongLength > 0)
+            else if (hasBinaryData)
             {
                 Stream s = new MemoryStream(ssBinary_Data);
                 p.Load(s);


### PR DESCRIPTION
This PR fixes five bugs found while reviewing the C# wrapper. Each is an isolated, low-risk change; no public action signatures change.

### What this changes

1. **`MssConditionalFormatting_AddRule` – `TopPercent` was inverted.**
   The `TopPercent` case called `ws.ConditionalFormatting.AddBottomPercent(address)`, so a "top N percent" rule was created as "bottom N percent". Now calls `AddTopPercent`.

2. **`MssWorksheet_Protect` – password from the options struct was ignored.**
   When the password was supplied through `ProtectionOptions.Password` (and not the top-level parameter), the code called `SetPassword(ssPassword)` using the empty top-level parameter, so an empty password was set. It now uses `ssProtectionOptions.ssSTProtection.ssPassword`.

3. **`MssWorksheet_GetImages` – returned N copies of the last image.**
   A single `RCImageRecord` was created once and the same reference was appended on every iteration, so all entries ended up pointing at the last picture. The record is now created per iteration. Also, drawings that are not pictures (e.g. charts) are skipped instead of throwing a `NullReferenceException` on `picture.Image`.

4. **`MssRow_Delete` / `MssColumn_Delete` – off-by-one removing cell comments.**
   Before deleting, the methods remove cell comments in the affected range. The loops used `<=` against `start + count`, iterating one row/column past the range and removing a comment from a row/column that was not being deleted. Changed to `<`.

5. **`MssCell_WriteRange` – format applied to one cell only.**
   `CellFormat` was applied to `Cells[ssRowStart, ssColumnStart]` (the top-left cell) instead of the written block. It now formats the full range returned by `LoadFromDataTable`, matching `MssCell_WriteRangeWithFormat`.

6. **`MssWorkbook_Open` – `NullReferenceException` on `nullbinary()`.**
   The guard dereferenced `ssBinary_Data.LongLength` before null-checking, so opening by filename (with `nullbinary()` binary) threw an NRE instead of loading the file. Binary data is now null-checked, and the HTTP response/stream in the URL branch are disposed.

### Notes
- Behaviour-only fixes; no changes to the extension's interface.
- Added a `.gitattributes` to normalise line endings to LF so future diffs stay clean.
- Built/reviewed against the existing source; not yet run through a full platform publish on my side.

Happy to split this into separate PRs if you'd prefer to review them individually. I'd also like to follow up on the items in `ToDo.txt` (reading a range into a record list, and the unimplemented conditional-formatting rule types).
