### PR TITLE
Fix image-handle leak and preserve image format

### DIFF
--- a/Advanced_Excel/Source/NET/Advanced_Excel.cs
+++ b/Advanced_Excel/Source/NET/Advanced_Excel.cs
@@ -468,9 +468,12 @@ namespace OutSystems.NssAdvanced_Excel
         {
             ExcelWorksheet ws = (ExcelWorksheet)ssWorksheet;
 
-            Image i = Image.FromStream(new MemoryStream(ssImage));
-            ExcelPicture pic = ws.Drawings.AddPicture(ssImageName, i);
-            pic.SetPosition(ssRow, 0, ssColumn, 0);
+            using (MemoryStream ms = new MemoryStream(ssImage))
+            using (Image i = Image.FromStream(ms))
+            {
+                ExcelPicture pic = ws.Drawings.AddPicture(ssImageName, i);
+                pic.SetPosition(ssRow, 0, ssColumn, 0);
+            }
         } // MssCell_WriteImageByIndex
 
         /// <summary>

--- a/Advanced_Excel/Source/NET/Util.cs
+++ b/Advanced_Excel/Source/NET/Util.cs
@@ -59,7 +59,12 @@ namespace OutSystems.NssAdvanced_Excel
         {
             using (var ms = new MemoryStream())
             {
-                imageIn.Save(ms, System.Drawing.Imaging.ImageFormat.Gif);
+                System.Drawing.Imaging.ImageFormat format = imageIn.RawFormat;
+                if (format == null || format.Guid == System.Drawing.Imaging.ImageFormat.MemoryBmp.Guid)
+                {
+                    format = System.Drawing.Imaging.ImageFormat.Png;
+                }
+                imageIn.Save(ms, format);
                 return ms.ToArray();
             }
         }


### PR DESCRIPTION
- Cell_WriteImageByIndex: dispose the Image and MemoryStream (previously leaked on every call).
- Util.ImageToByteArray (used by Worksheet_GetImages): keep the original image format instead of always re-encoding as GIF, falling back to PNG for formats that cannot be written directly.