### PR TITLE
Fix image-handle leak and preserve image format

### DIFF
--- a/Advanced_Excel/Source/NET/Advanced_Excel.cs
+++ b/Advanced_Excel/Source/NET/Advanced_Excel.cs
@@ -578,9 +578,12 @@ namespace OutSystems.NssAdvanced_Excel
         {
             ExcelWorksheet ws = (ExcelWorksheet)ssWorksheet;
 
-            Image i = Image.FromStream(new MemoryStream(ssImage));
-            ExcelPicture pic = ws.Drawings.AddPicture(ssImageName, i);
-            pic.SetPosition(ssRow, 0, ssColumn, 0);
+            using (MemoryStream ms = new MemoryStream(ssImage))
+            using (Image i = Image.FromStream(ms))
+            {
+                ExcelPicture pic = ws.Drawings.AddPicture(ssImageName, i);
+                pic.SetPosition(ssRow, 0, ssColumn, 0);
+            }
         } // MssCell_WriteImageByIndex
 
         /// <summary>

--- a/Advanced_Excel/Source/NET/Util.cs
+++ b/Advanced_Excel/Source/NET/Util.cs
@@ -59,7 +59,12 @@ namespace OutSystems.NssAdvanced_Excel
         {
             using (var ms = new MemoryStream())
             {
-                imageIn.Save(ms, System.Drawing.Imaging.ImageFormat.Gif);
+                System.Drawing.Imaging.ImageFormat format = imageIn.RawFormat;
+                if (format == null || format.Guid == System.Drawing.Imaging.ImageFormat.MemoryBmp.Guid)
+                {
+                    format = System.Drawing.Imaging.ImageFormat.Png;
+                }
+                imageIn.Save(ms, format);
                 return ms.ToArray();
             }
         }


### PR DESCRIPTION
Two small, isolated fixes on top of the current `master`. No public action signatures change.

1. **`MssCell_WriteImageByIndex` – leaked image handles.** The `Image` and `MemoryStream` were never disposed (a leak on every call). They are now wrapped in `using` blocks.

2. **`MssWorksheet_GetImages` – images were always re-encoded as GIF.** `Util.ImageToByteArray` saved every image as GIF regardless of the original format (lossy, wrong type). It now preserves the original format, falling back to PNG for formats that cannot be written directly.

Branched from the latest `master` (after the earlier fixes and the freeze/merged-range/RTL actions), so it's a single clean commit.