### PR TITLE
Fix Workbook_Open, DeleteRule, image position; tidy csproj refs

### DIFF
--- a/Advanced_Excel/Source/NET/Advanced_Excel.cs
+++ b/Advanced_Excel/Source/NET/Advanced_Excel.cs
@@ -582,7 +582,7 @@ namespace OutSystems.NssAdvanced_Excel
             using (Image i = Image.FromStream(ms))
             {
                 ExcelPicture pic = ws.Drawings.AddPicture(ssImageName, i);
-                pic.SetPosition(ssRow, 0, ssColumn, 0);
+                pic.SetPosition(ssRow - 1, 0, ssColumn - 1, 0);
             }
         } // MssCell_WriteImageByIndex
 
@@ -1190,7 +1190,7 @@ namespace OutSystems.NssAdvanced_Excel
             }
 
             ExcelWorksheet ws = ssWorksheet as ExcelWorksheet;
-            ws.ConditionalFormatting.RemoveAt(ssRuleToDeleteIndex);
+            ws.ConditionalFormatting.RemoveAt(ssRuleToDeleteIndex - 1);
         } // MssConditionalFormatting_DeleteRule
 
         /// <summary>
@@ -1875,7 +1875,7 @@ namespace OutSystems.NssAdvanced_Excel
         /// <param name="ssHidden">A Boolean value, set to True to hide the column, and to False to show the column.</param>
         public void MssColumn_Hide_Show(object ssWorksheet, int ssColumn, bool ssHidden)
         {
-            ExcelWorksheet ws = ssWorksheet as ExcelWorksheet; ;
+            ExcelWorksheet ws = ssWorksheet as ExcelWorksheet;
 
             ws.Column(ssColumn).Hidden = ssHidden;
 
@@ -2266,7 +2266,10 @@ namespace OutSystems.NssAdvanced_Excel
             }
             else if (!string.IsNullOrEmpty(ssFileName))
             {
-                p.Load(System.IO.File.Open(ssFileName, System.IO.FileMode.OpenOrCreate));
+                using (FileStream fs = System.IO.File.Open(ssFileName, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.Read))
+                {
+                    p.Load(fs);
+                }
             }
             else if (hasBinaryData)
             {
@@ -2373,7 +2376,6 @@ namespace OutSystems.NssAdvanced_Excel
             chart.SetPosition(ssRowPos, 0, ssColPos, 0);
             chart.SetSize(ssWidth, ssHeight);
 
-            STDataSeriesStructure curr_series = ssDataSeries_List.CurrentRec;
             for (int i = 0; i < ssDataSeries_List.Count; i++)
             {
                 STRangeStructure valuerange = ssDataSeries_List.CurrentRec.ssSTDataSeries.ssValueRange.ssSTRange;

--- a/Advanced_Excel/Source/NET/Advanced_Excel.csproj
+++ b/Advanced_Excel/Source/NET/Advanced_Excel.csproj
@@ -40,10 +40,6 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EPPlus, Version=0.0.0.0, Culture=neutral, PublicKeyToken=ea159fdaa78159a1, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\EPPlus\EPPlus\bin\Release\EPPlus.dll</HintPath>
-    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="System">
       <Name>System</Name>
@@ -65,11 +61,6 @@
     <Reference Include="OutSystems.HubEdition.RuntimePlatform">
       <Name>OutSystems.HubEdition.RuntimePlatform</Name>
       <HintPath>bin\OutSystems.HubEdition.RuntimePlatform.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="OutSystems.HubEdition.SMS">
-      <Name>OutSystems.HubEdition.SMS</Name>
-      <HintPath>bin\OutSystems.HubEdition.SMS.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="OutSystems.RuntimeCommon">


### PR DESCRIPTION
Five small, isolated fixes on top of current `master`. Each is independently safe, all confirmed against EPPlus 4.x semantics and the current project layout.

### What this changes

1. **`MssWorkbook_Open` — file branch left junk files and locked them.**
   `File.Open(path, FileMode.OpenOrCreate)` silently created a 0-byte file on a typo'd path (then EPPlus failed with a cryptic *"central directory not found"*), and the `FileStream` was never disposed, so the file stayed locked by the app-pool process until GC.
   Now uses `FileMode.Open` / `FileAccess.Read` / `FileShare.Read` and disposes the stream via `using`.

2. **`MssConditionalFormatting_DeleteRule` deleted the wrong rule.**
   The guard requires `index >= 1`, but `ExcelConditionalFormattingCollection.RemoveAt(...)` is a standard **0-based** collection. So the first rule could never be deleted (it would remove rule 2), and every other index was off by one. Now passes `ssRuleToDeleteIndex - 1`.

3. **`MssCell_WriteImageByIndex` / `MssCell_WriteImageByName` placed the image one cell down-right.**
   EPPlus's `ExcelPicture.SetPosition(row, …, col, …)` takes a **0-based** anchor. The wrapper passed the OutSystems 1-based row/column raw, so writing to `A4` actually landed at `B5`. `Image_Insert` already converted correctly (`range.Start.Row - 1`); this brings the two image actions in line.

4. **Minor cleanup**: stray double semicolon in `MssColumn_Hide_Show` and a dead `STDataSeriesStructure curr_series` local in `MssChart_Create`.

5. **csproj: drop two unresolved references that warn on every build.**
   - Duplicate **EPPlus** reference whose `HintPath` (`..\..\..\..\EPPlus\EPPlus\bin\Release\EPPlus.dll`) points to a sibling source tree most contributors don't have. The project keeps a second EPPlus reference (`Bin\EPPlus.dll`) which is what actually compiles, so the duplicate is dead weight.
   - **OutSystems.HubEdition.SMS** reference whose `HintPath` (`bin\OutSystems.HubEdition.SMS.dll`) points at a DLL that isn't in `Bin\`. No code in the extension references any SMS type, the reference was marked `<Private>False</Private>` (not deployed), and the build succeeds without it.

   Removes the two `CS` warnings without changing build output. Verified: the remaining EPPlus reference resolves to `Bin\EPPlus.dll`, and `grep` finds zero `OutSystems.HubEdition.SMS` usages in the codebase.

### Notes
- Behaviour-only fixes; no changes to the extension's interface.
- Worth a brief release-note line for #3 in case any consumer compensated for the off-by-one in their app logic.
- The `Workbook_Protect` encryption-vs-protection confusion, post-`GetAsByteArray` package state, `Worksheet_SetActive` grouped-sheets quirk, and the `Sheet1, Sheet12, Sheet13` default-naming are split out as issues (#39–#42) for your call.