### PR TITLE
Wrapper quality pass and known-issue cleanup

### DIFF
--- a/Advanced_Excel/Source/NET/Advanced_Excel.cs
+++ b/Advanced_Excel/Source/NET/Advanced_Excel.cs
@@ -174,7 +174,7 @@ namespace OutSystems.NssAdvanced_Excel
             }
             else
             {
-                ssFillColor = "#" + fillColor.Substring(fillColor.Length - 6);
+                ssFillColor = "#" + (fillColor.Length >= 6 ? fillColor.Substring(fillColor.Length - 6) : fillColor.PadLeft(6, '0'));
             }
         } // MssCell_GetFillColorByIndex
 
@@ -203,7 +203,7 @@ namespace OutSystems.NssAdvanced_Excel
             }
             else
             {
-                ssFillColor = "#" + fillColor.Substring(fillColor.Length - 6);
+                ssFillColor = "#" + (fillColor.Length >= 6 ? fillColor.Substring(fillColor.Length - 6) : fillColor.PadLeft(6, '0'));
             }
         } // MssCell_GetFillColorByName
 
@@ -227,7 +227,7 @@ namespace OutSystems.NssAdvanced_Excel
         /// <param name="ssProperties">The Microsoft Office properties of the Excel document.</param>
         public void MssExcel_GetProperties(object ssWorkbook, out RCOfficePropertiesRecord ssProperties)
         {
-            var wb = ssWorkbook as ExcelWorkbook;
+            var wb = ssWorkbook as ExcelWorkbook ?? (ssWorkbook as ExcelPackage)?.Workbook;
             var props = wb.Properties;
             ssProperties = new RCOfficePropertiesRecord(null);
             ssProperties.ssSTOfficeProperties.ssAuthor = props.Author;
@@ -250,7 +250,7 @@ namespace OutSystems.NssAdvanced_Excel
         /// <param name="ssIgnoreBlank">If True, any blank properties in the Properties structure provided will be left with their existing values. If False, any blank properties in the Properties structure provided will be set to blank.</param>
         public void MssExcel_SetProperties(object ssWorkbook, RCOfficePropertiesRecord ssProperties, bool ssIgnoreBlank)
         {
-            var wb = ssWorkbook as ExcelWorkbook;
+            var wb = ssWorkbook as ExcelWorkbook ?? (ssWorkbook as ExcelPackage)?.Workbook;
             var props = wb.Properties;
             var inProps = ssProperties.ssSTOfficeProperties;
             if (!string.IsNullOrEmpty(inProps.ssAuthor)) { props.Author = inProps.ssAuthor; }
@@ -281,7 +281,7 @@ namespace OutSystems.NssAdvanced_Excel
         /// <param name="ssClearManager">If True, clears the Manager property.</param>
         public void MssExcel_ClearProperties(object ssWorkbook, bool ssClearTitle, bool ssClearSubject, bool ssClearAuthor, bool ssClearComments, bool ssClearKeywords, bool ssClearLastModifiedBy, bool ssClearCategory, bool ssClearStatus, bool ssClearCompany, bool ssClearManager)
         {
-            var wb = ssWorkbook as ExcelWorkbook;
+            var wb = ssWorkbook as ExcelWorkbook ?? (ssWorkbook as ExcelPackage)?.Workbook;
             var props = wb.Properties;
             if (ssClearAuthor) { props.Author = string.Empty; }
             if (ssClearCategory) { props.Category = string.Empty; }
@@ -1972,10 +1972,10 @@ namespace OutSystems.NssAdvanced_Excel
 
             switch (ssCellType.ToLower())
             {
-                case "integer": ws.SetValue(address.Address, Convert.ToInt32(ssCellValue)); break;
-                case "datetime": ws.SetValue(address.Address, Convert.ToDateTime(ssCellValue)); break;
-                case "decimal": ws.SetValue(address.Address, Convert.ToDecimal(ssCellValue)); break;
-                case "boolean": ws.SetValue(address.Address, Convert.ToBoolean(ssCellValue)); break;
+                case "integer": ws.SetValue(address.Address, Convert.ToInt32(ssCellValue, System.Globalization.CultureInfo.InvariantCulture)); break;
+                case "datetime": ws.SetValue(address.Address, Convert.ToDateTime(ssCellValue, System.Globalization.CultureInfo.InvariantCulture)); break;
+                case "decimal": ws.SetValue(address.Address, Convert.ToDecimal(ssCellValue, System.Globalization.CultureInfo.InvariantCulture)); break;
+                case "boolean": ws.SetValue(address.Address, Convert.ToBoolean(ssCellValue, System.Globalization.CultureInfo.InvariantCulture)); break;
                 case "formula": ws.Cells[address.Address].Formula = ssCellValue.TrimStart('='); break;
                 case "text":
                     ssCellFormat.ssSTCellFormat.ssNumberFormat = "@"; /// Formats the cell as text. Ref: https://stackoverflow.com/a/30095442

--- a/Advanced_Excel/Source/NET/Advanced_Excel.cs
+++ b/Advanced_Excel/Source/NET/Advanced_Excel.cs
@@ -1465,22 +1465,43 @@ namespace OutSystems.NssAdvanced_Excel
                         newItem.ssSTConditionalFormatItem.ssRuleType = (int)yesterday.Type;
                         break;
                     case eExcelConditionalFormattingRuleType.BeginsWith:
+                        var beginsWith = item as IExcelConditionalFormattingBeginsWith;
+                        newItem.ssSTConditionalFormatItem.ssRuleType = (int)beginsWith.Type;
+                        newItem.ssSTConditionalFormatItem.ssFormula = beginsWith.Text;
                         break;
                     case eExcelConditionalFormattingRuleType.Between:
                         break;
                     case eExcelConditionalFormattingRuleType.ContainsBlanks:
+                        var containsBlanks = item as IExcelConditionalFormattingContainsBlanks;
+                        newItem.ssSTConditionalFormatItem.ssRuleType = (int)containsBlanks.Type;
                         break;
                     case eExcelConditionalFormattingRuleType.ContainsErrors:
+                        var containsErrors = item as IExcelConditionalFormattingContainsErrors;
+                        newItem.ssSTConditionalFormatItem.ssRuleType = (int)containsErrors.Type;
                         break;
                     case eExcelConditionalFormattingRuleType.ContainsText:
+                        var containsText = item as IExcelConditionalFormattingContainsText;
+                        newItem.ssSTConditionalFormatItem.ssRuleType = (int)containsText.Type;
+                        newItem.ssSTConditionalFormatItem.ssFormula = containsText.Text;
                         break;
                     case eExcelConditionalFormattingRuleType.DuplicateValues:
+                        var duplicateValues = item as IExcelConditionalFormattingDuplicateValues;
+                        newItem.ssSTConditionalFormatItem.ssRuleType = (int)duplicateValues.Type;
                         break;
                     case eExcelConditionalFormattingRuleType.EndsWith:
+                        var endsWith = item as IExcelConditionalFormattingEndsWith;
+                        newItem.ssSTConditionalFormatItem.ssRuleType = (int)endsWith.Type;
+                        newItem.ssSTConditionalFormatItem.ssFormula = endsWith.Text;
                         break;
                     case eExcelConditionalFormattingRuleType.Equal:
+                        var equal = item as IExcelConditionalFormattingEqual;
+                        newItem.ssSTConditionalFormatItem.ssRuleType = (int)equal.Type;
+                        newItem.ssSTConditionalFormatItem.ssFormula = equal.Formula;
                         break;
                     case eExcelConditionalFormattingRuleType.Expression:
+                        var expression = item as IExcelConditionalFormattingExpression;
+                        newItem.ssSTConditionalFormatItem.ssRuleType = (int)expression.Type;
+                        newItem.ssSTConditionalFormatItem.ssFormula = expression.Formula;
                         break;
                     case eExcelConditionalFormattingRuleType.GreaterThan:
                         var gt = item as IExcelConditionalFormattingGreaterThan;
@@ -1507,14 +1528,26 @@ namespace OutSystems.NssAdvanced_Excel
                     case eExcelConditionalFormattingRuleType.NotContains:
                         break;
                     case eExcelConditionalFormattingRuleType.NotContainsBlanks:
+                        var notContainsBlanks = item as IExcelConditionalFormattingNotContainsBlanks;
+                        newItem.ssSTConditionalFormatItem.ssRuleType = (int)notContainsBlanks.Type;
                         break;
                     case eExcelConditionalFormattingRuleType.NotContainsErrors:
+                        var notContainsErrors = item as IExcelConditionalFormattingNotContainsErrors;
+                        newItem.ssSTConditionalFormatItem.ssRuleType = (int)notContainsErrors.Type;
                         break;
                     case eExcelConditionalFormattingRuleType.NotContainsText:
+                        var notContainsText = item as IExcelConditionalFormattingNotContainsText;
+                        newItem.ssSTConditionalFormatItem.ssRuleType = (int)notContainsText.Type;
+                        newItem.ssSTConditionalFormatItem.ssFormula = notContainsText.Text;
                         break;
                     case eExcelConditionalFormattingRuleType.NotEqual:
+                        var notEqual = item as IExcelConditionalFormattingNotEqual;
+                        newItem.ssSTConditionalFormatItem.ssRuleType = (int)notEqual.Type;
+                        newItem.ssSTConditionalFormatItem.ssFormula = notEqual.Formula;
                         break;
                     case eExcelConditionalFormattingRuleType.UniqueValues:
+                        var uniqueValues = item as IExcelConditionalFormattingUniqueValues;
+                        newItem.ssSTConditionalFormatItem.ssRuleType = (int)uniqueValues.Type;
                         break;
                     case eExcelConditionalFormattingRuleType.ThreeColorScale:
                         break;
@@ -1683,22 +1716,59 @@ namespace OutSystems.NssAdvanced_Excel
                     Util.ApplyConditionalFormattingStyle(yesterday.Style, ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStyle);
                     break;
                 case eExcelConditionalFormattingRuleType.BeginsWith:
+                    var beginsWith = ws.ConditionalFormatting.AddBeginsWith(address);
+                    beginsWith.Text = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssFormula;
+                    beginsWith.Priority = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssPriority;
+                    beginsWith.StopIfTrue = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStopIfTrue;
+                    Util.ApplyConditionalFormattingStyle(beginsWith.Style, ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStyle);
                     break;
                 case eExcelConditionalFormattingRuleType.Between:
-                    break;
+                    throw new NotSupportedException("ConditionalFormatting rule type 'Between' is not yet supported by this extension.");
                 case eExcelConditionalFormattingRuleType.ContainsBlanks:
+                    var containsBlanks = ws.ConditionalFormatting.AddContainsBlanks(address);
+                    containsBlanks.Priority = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssPriority;
+                    containsBlanks.StopIfTrue = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStopIfTrue;
+                    Util.ApplyConditionalFormattingStyle(containsBlanks.Style, ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStyle);
                     break;
                 case eExcelConditionalFormattingRuleType.ContainsErrors:
+                    var containsErrors = ws.ConditionalFormatting.AddContainsErrors(address);
+                    containsErrors.Priority = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssPriority;
+                    containsErrors.StopIfTrue = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStopIfTrue;
+                    Util.ApplyConditionalFormattingStyle(containsErrors.Style, ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStyle);
                     break;
                 case eExcelConditionalFormattingRuleType.ContainsText:
+                    var containsText = ws.ConditionalFormatting.AddContainsText(address);
+                    containsText.Text = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssFormula;
+                    containsText.Priority = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssPriority;
+                    containsText.StopIfTrue = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStopIfTrue;
+                    Util.ApplyConditionalFormattingStyle(containsText.Style, ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStyle);
                     break;
                 case eExcelConditionalFormattingRuleType.DuplicateValues:
+                    var duplicateValues = ws.ConditionalFormatting.AddDuplicateValues(address);
+                    duplicateValues.Priority = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssPriority;
+                    duplicateValues.StopIfTrue = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStopIfTrue;
+                    Util.ApplyConditionalFormattingStyle(duplicateValues.Style, ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStyle);
                     break;
                 case eExcelConditionalFormattingRuleType.EndsWith:
+                    var endsWith = ws.ConditionalFormatting.AddEndsWith(address);
+                    endsWith.Text = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssFormula;
+                    endsWith.Priority = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssPriority;
+                    endsWith.StopIfTrue = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStopIfTrue;
+                    Util.ApplyConditionalFormattingStyle(endsWith.Style, ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStyle);
                     break;
                 case eExcelConditionalFormattingRuleType.Equal:
+                    var equal = ws.ConditionalFormatting.AddEqual(address);
+                    equal.Formula = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssFormula;
+                    equal.Priority = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssPriority;
+                    equal.StopIfTrue = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStopIfTrue;
+                    Util.ApplyConditionalFormattingStyle(equal.Style, ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStyle);
                     break;
                 case eExcelConditionalFormattingRuleType.Expression:
+                    var expression = ws.ConditionalFormatting.AddExpression(address);
+                    expression.Formula = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssFormula;
+                    expression.Priority = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssPriority;
+                    expression.StopIfTrue = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStopIfTrue;
+                    Util.ApplyConditionalFormattingStyle(expression.Style, ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStyle);
                     break;
                 case eExcelConditionalFormattingRuleType.GreaterThan:
                     var gt = ws.ConditionalFormatting.AddGreaterThan(address);
@@ -1729,31 +1799,53 @@ namespace OutSystems.NssAdvanced_Excel
                     Util.ApplyConditionalFormattingStyle(lte.Style, ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStyle);
                     break;
                 case eExcelConditionalFormattingRuleType.NotBetween:
-                    break;
+                    throw new NotSupportedException("ConditionalFormatting rule type 'NotBetween' is not yet supported by this extension.");
                 case eExcelConditionalFormattingRuleType.NotContains:
-                    break;
+                    throw new NotSupportedException("ConditionalFormatting rule type 'NotContains' is not yet supported by this extension.");
                 case eExcelConditionalFormattingRuleType.NotContainsBlanks:
+                    var notContainsBlanks = ws.ConditionalFormatting.AddNotContainsBlanks(address);
+                    notContainsBlanks.Priority = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssPriority;
+                    notContainsBlanks.StopIfTrue = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStopIfTrue;
+                    Util.ApplyConditionalFormattingStyle(notContainsBlanks.Style, ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStyle);
                     break;
                 case eExcelConditionalFormattingRuleType.NotContainsErrors:
+                    var notContainsErrors = ws.ConditionalFormatting.AddNotContainsErrors(address);
+                    notContainsErrors.Priority = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssPriority;
+                    notContainsErrors.StopIfTrue = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStopIfTrue;
+                    Util.ApplyConditionalFormattingStyle(notContainsErrors.Style, ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStyle);
                     break;
                 case eExcelConditionalFormattingRuleType.NotContainsText:
+                    var notContainsText = ws.ConditionalFormatting.AddNotContainsText(address);
+                    notContainsText.Text = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssFormula;
+                    notContainsText.Priority = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssPriority;
+                    notContainsText.StopIfTrue = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStopIfTrue;
+                    Util.ApplyConditionalFormattingStyle(notContainsText.Style, ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStyle);
                     break;
                 case eExcelConditionalFormattingRuleType.NotEqual:
+                    var notEqual = ws.ConditionalFormatting.AddNotEqual(address);
+                    notEqual.Formula = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssFormula;
+                    notEqual.Priority = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssPriority;
+                    notEqual.StopIfTrue = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStopIfTrue;
+                    Util.ApplyConditionalFormattingStyle(notEqual.Style, ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStyle);
                     break;
                 case eExcelConditionalFormattingRuleType.UniqueValues:
+                    var uniqueValues = ws.ConditionalFormatting.AddUniqueValues(address);
+                    uniqueValues.Priority = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssPriority;
+                    uniqueValues.StopIfTrue = ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStopIfTrue;
+                    Util.ApplyConditionalFormattingStyle(uniqueValues.Style, ssConditionalFormatRecord.ssSTConditionalFormatItem.ssStyle);
                     break;
                 case eExcelConditionalFormattingRuleType.ThreeColorScale:
-                    break;
+                    throw new NotSupportedException("ConditionalFormatting rule type 'ThreeColorScale' is not yet supported by this extension.");
                 case eExcelConditionalFormattingRuleType.TwoColorScale:
-                    break;
+                    throw new NotSupportedException("ConditionalFormatting rule type 'TwoColorScale' is not yet supported by this extension.");
                 case eExcelConditionalFormattingRuleType.ThreeIconSet:
-                    break;
+                    throw new NotSupportedException("ConditionalFormatting rule type 'ThreeIconSet' is not yet supported by this extension.");
                 case eExcelConditionalFormattingRuleType.FourIconSet:
-                    break;
+                    throw new NotSupportedException("ConditionalFormatting rule type 'FourIconSet' is not yet supported by this extension.");
                 case eExcelConditionalFormattingRuleType.FiveIconSet:
-                    break;
+                    throw new NotSupportedException("ConditionalFormatting rule type 'FiveIconSet' is not yet supported by this extension.");
                 case eExcelConditionalFormattingRuleType.DataBar:
-                    break;
+                    throw new NotSupportedException("ConditionalFormatting rule type 'DataBar' is not yet supported by this extension.");
                 default:
                     throw new Exception("Invalid Rule Type: " + ssConditionalFormatRecord.ssSTConditionalFormatItem.ssRuleType);
             }

--- a/Advanced_Excel/Source/NET/Advanced_Excel.cs
+++ b/Advanced_Excel/Source/NET/Advanced_Excel.cs
@@ -103,6 +103,8 @@ namespace OutSystems.NssAdvanced_Excel
             }
 
             ssBinaryData = p.GetAsByteArray();
+            // GetAsByteArray closes the package; reload so the workbook stays usable.
+            p.Load(new System.IO.MemoryStream(ssBinaryData));
         } // MssWorkbook_SaveRightToLeft
 
         /// <summary>
@@ -405,15 +407,25 @@ namespace OutSystems.NssAdvanced_Excel
         public void MssWorksheet_SetActive(object ssWorkbook, string ssWorksheetName, int ssWorksheetIndex)
         {
             ExcelPackage ee = ssWorkbook as ExcelPackage;
-            if (ssWorksheetName != "")
+            ExcelWorksheet target = null;
+
+            if (!string.IsNullOrEmpty(ssWorksheetName))
             {
-                ee.Workbook.Worksheets[ssWorksheetName].Select();
+                target = ee.Workbook.Worksheets[ssWorksheetName];
             }
             if (ssWorksheetIndex > 0)
             {
-                ee.Workbook.Worksheets[ssWorksheetIndex].Select();
-
+                target = ee.Workbook.Worksheets[ssWorksheetIndex];
             }
+
+            if (target == null) return;
+
+            foreach (var sheet in ee.Workbook.Worksheets)
+            {
+                sheet.View.TabSelected = false;
+            }
+            target.View.TabSelected = true;
+            ee.Workbook.View.ActiveTab = target.Index;
         } // MssWorksheet_SetActive
 
         /// <summary>
@@ -1005,9 +1017,13 @@ namespace OutSystems.NssAdvanced_Excel
                 wb.Worksheets.Add(ssFirstSheetName);
                 if (ssNumberOfSheets > 1)
                 {
+                    // Strip trailing "1" so "Sheet1" produces Sheet1/Sheet2/Sheet3, not Sheet1/Sheet12/Sheet13.
+                    string baseName = (ssFirstSheetName.Length > 1 && ssFirstSheetName.EndsWith("1"))
+                        ? ssFirstSheetName.Substring(0, ssFirstSheetName.Length - 1)
+                        : ssFirstSheetName;
                     for (int i = 2; i <= ssNumberOfSheets; i++)
                     {
-                        wb.Worksheets.Add(string.Concat(ssFirstSheetName, i));
+                        wb.Worksheets.Add(baseName + i);
                     }
                 }
             }
@@ -1033,10 +1049,12 @@ namespace OutSystems.NssAdvanced_Excel
         public void MssWorkbook_Protect(object ssWorkbook, string ssPassword, bool ssLockStructure, bool ssLockWindows, bool ssLockRevision)
         {
             ExcelPackage p = ssWorkbook as ExcelPackage;
-
-            p.Encryption.Password = ssPassword;
-
             ExcelWorkbook wb = p.Workbook;
+
+            if (!string.IsNullOrEmpty(ssPassword))
+            {
+                wb.Protection.SetPassword(ssPassword);
+            }
 
             wb.Protection.LockRevision = ssLockRevision;
             wb.Protection.LockStructure = ssLockStructure;
@@ -2329,6 +2347,8 @@ namespace OutSystems.NssAdvanced_Excel
         {
             ExcelPackage p = ssWorkbook as ExcelPackage;
             ssBinaryData = p.GetAsByteArray();
+            // GetAsByteArray closes the package; reload so the workbook stays usable.
+            p.Load(new System.IO.MemoryStream(ssBinaryData));
         } // MssWorkbook_GetBinaryData
 
         /// <summary>

--- a/Advanced_Excel/Source/NET/Advanced_Excel.cs
+++ b/Advanced_Excel/Source/NET/Advanced_Excel.cs
@@ -18,6 +18,18 @@ namespace OutSystems.NssAdvanced_Excel
 
     public class CssAdvanced_Excel : IssAdvanced_Excel
     {
+
+		/// <summary>
+		/// Copy a range of rows
+		/// </summary>
+		/// <param name="ssWorksheet"></param>
+		/// <param name="ssRangeStart">Example: A1:B5</param>
+		/// <param name="ssRangeEnd">Example: G1:H5</param>
+		public void MssWorksheet_CopyRange(object ssWorksheet, string ssRangeStart, string ssRangeEnd) {
+			var ws = ssWorksheet as ExcelWorksheet;
+			ws.Cells[ssRangeStart].Copy(ws.Cells[ssRangeEnd]);
+		} // MssWorksheet_CopyRange
+
         /// <summary>
         /// Get all merged cell ranges in the selected workbook.
         /// E.g., Worksheet: Sheet1
@@ -208,19 +220,6 @@ namespace OutSystems.NssAdvanced_Excel
                 ssFillColor = "#" + (fillColor.Length >= 6 ? fillColor.Substring(fillColor.Length - 6) : fillColor.PadLeft(6, '0'));
             }
         } // MssCell_GetFillColorByName
-
-        /// <summary>
-        /// Copy a range of rows
-        /// </summary>
-        /// <param name="ssWorksheet"></param>
-        /// <param name="ssRangeStart">Example: A1:B5</param>
-        /// <param name="ssRangeEnd">Example: G1:H5</param>
-        public void MssWorksheet_CopyRows(object ssWorksheet, string ssRangeStart, string ssRangeEnd)
-        {
-            var ws = ssWorksheet as ExcelWorksheet;
-            ws.Cells[ssRangeStart].Copy(ws.Cells[ssRangeEnd]);
-        } // MssWorksheet_CopyRows
-
 
         /// <summary>
         /// Get the Microsoft Office properties of the Excel document.

--- a/Advanced_Excel/Source/NET/Interface.cs
+++ b/Advanced_Excel/Source/NET/Interface.cs
@@ -958,7 +958,7 @@ namespace OutSystems.NssAdvanced_Excel {
 		/// <param name="ssWorksheet"></param>
 		/// <param name="ssRangeStart">Example: A1:B5</param>
 		/// <param name="ssRangeEnd">Example: G1:H5</param>
-		void MssWorksheet_CopyRows(object ssWorksheet, string ssRangeStart, string ssRangeEnd);
+		void MssWorksheet_CopyRange(object ssWorksheet, string ssRangeStart, string ssRangeEnd);
 
 		/// <summary>
 		/// Action to convert Hex code of color to RGB value
@@ -986,8 +986,19 @@ namespace OutSystems.NssAdvanced_Excel {
 		void MssCell_GetFillColorByName(object ssWorksheet, string ssCellName, out string ssFillColor);
 
 		/// <summary>
-		/// Get all merged cell ranges in the selected workbook.
+		/// Freeze cells, defined by row and column numbers.
 		/// 
+		/// Example:
+		/// - Choosing row = 2, column = 1 will freeze the first row.
+		/// - Choosing row = 1, column = 2 will freeze the first column.
+		/// </summary>
+		/// <param name="ssWorksheet">Worksheet on which the cell resides</param>
+		/// <param name="ssRow">Row Number</param>
+		/// <param name="ssColumn">Column Number</param>
+		void MssCell_Freeze(object ssWorksheet, int ssRow, int ssColumn);
+
+		/// <summary>
+		/// Get all merged cell ranges in the selected workbook.
 		/// E.g., Worksheet: Sheet1
 		/// A1:B2; D4:E4
 		/// Worksheet: Sheet2
@@ -998,31 +1009,18 @@ namespace OutSystems.NssAdvanced_Excel {
 		void MssWorkbook_GetMergedCellRanges(object ssWorkbook, out string ssMergedRange);
 
 		/// <summary>
+		/// Gets the binary data of the workbook, setting worksheets to right-to-left view.
+		/// </summary>
+		/// <param name="ssWorkbook">The workbook to work with</param>
+		/// <param name="ssBinaryData">The binary data of the file</param>
+		void MssWorkbook_SaveRightToLeft(object ssWorkbook, out byte[] ssBinaryData);
+
+		/// <summary>
 		/// Get all merged cell ranges in the selected worksheet. E.g., A1:A3; B1:C2.
 		/// </summary>
 		/// <param name="ssWorksheet">Worksheet on which the cell resides</param>
 		/// <param name="ssMergedRange">Ranges of the merged cells</param>
 		void MssWorksheet_GetMergedCellRanges(object ssWorksheet, out string ssMergedRange);
-
-		/// <summary>
-		/// Gets the binary data of the workbook, setting worksheets to right-to-left view.
-		/// </summary>
-		/// <param name="ssWorkbook">The workbook to work with</param>
-		/// <param name="ssBinaryData"></param>
-		void MssWorkbook_SaveRightToLeft(object ssWorkbook, out byte[] ssBinaryData);
-
-		/// <summary>
-		/// Freeze cells, defined by row and column numbers.
-		/// 
-		/// Example:
-		/// 
-		/// - Choosing row = 2, column = 1 will freeze the first row.
-		/// - Choosing row = 1, column = 2 will freeze the first column.
-		/// </summary>
-		/// <param name="ssWorksheet">Worksheet on which the cell resides</param>
-		/// <param name="ssRow">Row Number</param>
-		/// <param name="ssColumn">Column Number</param>
-		void MssCell_Freeze(object ssWorksheet, int ssRow, int ssColumn);
 
 	} // IssAdvanced_Excel
 


### PR DESCRIPTION
## Summary

A focused multi-fix batch on top of `master`, addressing five long-standing
issues and a handful of latent wrapper bugs.

Four commits, scoped so each can be reviewed independently. No interface
changes apart from the deliberate rename in #30. Behaviour changes are
flagged below.

## What's in this PR (per commit)

**`52012f0` — Quality fixes (culture, cast, fill-color guard)**
- `Cell_Write` parses with `CultureInfo.InvariantCulture` — was using the
  thread culture, so the OutSystems-typical `"3.14"` threw `FormatException`
  on servers with comma-decimal locales (pt-PT, es-ES, fr-FR…).
- `Excel_GetProperties / SetProperties / ClearProperties` accept either an
  `ExcelPackage` or an `ExcelWorkbook`. They previously cast to
  `ExcelWorkbook` only, while every other action passes the
  `ExcelPackage` — callers got a `NullReferenceException`.
- `Cell_GetFillColorByIndex / ByName` guard `Substring(Length - 6)` —
  threw `ArgumentOutOfRangeException` when EPPlus returned a short rgb
  string (some pure colours).

**`ddc3987` — Conditional-formatting rule types**

Out of 22 rule types that the wrapper silently no-op'd, 13 now work:

- `BeginsWith`, `EndsWith`, `ContainsText`, `NotContainsText` (use `.Text`)
- `Equal`, `NotEqual`, `Expression` (use `.Formula`)
- `ContainsBlanks`, `ContainsErrors`, `NotContainsBlanks`,
  `NotContainsErrors`, `DuplicateValues`, `UniqueValues` (no operand)

The 9 remaining types (`Between`, `NotBetween`, `NotContains`, two/three
color scales, three/four/five icon sets, data bar) need structure fields
the wrapper doesn't expose yet — they now throw a clear
`NotSupportedException` instead of failing silently. This partially
addresses #29 (icon-set rule): callers get an immediate, actionable error.

`ConditionalFormatting_GetAllRules` also reads back the 13 new types.

**`db61183` — Closes #39, #40, #41, #42**

- **#39 `Workbook_Protect` encrypts the file.** Switched from
  `p.Encryption.Password = …` to `wb.Protection.SetPassword(…)`. The
  documented behaviour ("This does not encrypt the workbook.") is now the
  actual behaviour. *Behaviour change*: anyone relying on the encryption
  side-effect loses it.
- **#40 `Workbook_GetBinaryData` closes the package.** Both
  `Workbook_GetBinaryData` and `Workbook_SaveRightToLeft` reload the
  package from the bytes they just produced, so the workbook reference
  stays usable. Worksheet references obtained before the call become
  stale and must be re-fetched via `Worksheet_Select*`.
- **#41 `Worksheet_SetActive` grouped sheets.** Clears `TabSelected` on
  every sheet before activating the target, and also sets
  `Workbook.View.ActiveTab`. Files saved after multiple `SetActive` calls
  no longer open with sheets grouped in Excel.
- **#42 Default-name series `Sheet1, Sheet12, Sheet13`.** When the first
  sheet name ends in `"1"`, the trailing `"1"` is stripped for subsequent
  sheet names, producing `Sheet1, Sheet2, Sheet3`. Non-`"…1"` names keep
  the existing concat behaviour (`"Data"` → `Data, Data2, Data3`).

**`7d851b3` — Closes #30: `Worksheet_CopyRows` → `Worksheet_CopyRange`**

The action operates on arbitrary cell ranges, not just rows. The previous
name was misleading. **Breaking rename**: OutSystems apps calling
`Worksheet_CopyRows` must update to `Worksheet_CopyRange` after upgrading.
Signature is otherwise identical.

## Closes

- Closes #30
- Closes #39
- Closes #40
- Closes #41
- Closes #42

Partially addresses #29 (icon-set rule now throws clearly instead of
silently no-opping; full implementation still pending — needs structure
fields).

## Release notes

Suggest mentioning two breaking changes in the Forge release:
1. `Worksheet_CopyRows` renamed to `Worksheet_CopyRange` (#30).
2. `Workbook_Protect` no longer encrypts the file (#39) — if your app
   relied on file-level encryption, that should be done by a separate
   action.