### PR TITLE
Fix empty-sheet NullReferenceExceptions, transparent colors, and GetImages crash

### DIFF
--- a/Advanced_Excel/Source/NET/Advanced_Excel.cs
+++ b/Advanced_Excel/Source/NET/Advanced_Excel.cs
@@ -1165,6 +1165,10 @@ namespace OutSystems.NssAdvanced_Excel
 
             if (ssRangeToFilter == null || (ssRangeToFilter.ssSTRange.ssStartRow == 0 && ssRangeToFilter.ssSTRange.ssStartCol == 0 && ssRangeToFilter.ssSTRange.ssEndRow == 0 && ssRangeToFilter.ssSTRange.ssEndCol == 0))
             {
+                if (ws.Dimension == null)
+                {
+                    return;
+                }
                 startRow = ws.Dimension.Start.Row;
                 startCol = ws.Dimension.Start.Column;
                 endRow = ws.Dimension.End.Row;
@@ -1248,7 +1252,7 @@ namespace OutSystems.NssAdvanced_Excel
 
             // Delete all comments from cells in column(s) before deleting the column(s).
             // Considers the rows in the dimension of the worksheet to prevent unnecessary processing.
-            int nrRows = ws.Dimension.Rows;
+            int nrRows = ws.Dimension?.Rows ?? 0;
 
             for (int row = 1; row <= nrRows; row++)
             {
@@ -1312,7 +1316,7 @@ namespace OutSystems.NssAdvanced_Excel
 
             // Delete all comments from cells in row(s) before deleting the row(s).
             // Considers the columns in the dimension of the worksheet to prevent unnecessary processing.
-            int nrColumns = ws.Dimension.Columns;
+            int nrColumns = ws.Dimension?.Columns ?? 0;
 
             for (int col = 1; col <= nrColumns; col++)
             {

--- a/Advanced_Excel/Source/NET/Util.cs
+++ b/Advanced_Excel/Source/NET/Util.cs
@@ -57,14 +57,43 @@ namespace OutSystems.NssAdvanced_Excel
 
         public static byte[] ImageToByteArray(Image imageIn)
         {
+            if (imageIn == null)
+            {
+                return new byte[0];
+            }
+
             using (var ms = new MemoryStream())
             {
-                System.Drawing.Imaging.ImageFormat format = imageIn.RawFormat;
-                if (format == null || format.Guid == System.Drawing.Imaging.ImageFormat.MemoryBmp.Guid)
+                System.Drawing.Imaging.ImageFormat format = System.Drawing.Imaging.ImageFormat.Png;
+                try
                 {
-                    format = System.Drawing.Imaging.ImageFormat.Png;
+                    var raw = imageIn.RawFormat;
+                    if (raw != null && raw.Guid != System.Drawing.Imaging.ImageFormat.MemoryBmp.Guid)
+                    {
+                        format = raw;
+                    }
                 }
-                imageIn.Save(ms, format);
+                catch
+                {
+                }
+
+                try
+                {
+                    imageIn.Save(ms, format);
+                }
+                catch
+                {
+                    try
+                    {
+                        ms.SetLength(0);
+                        imageIn.Save(ms, System.Drawing.Imaging.ImageFormat.Png);
+                    }
+                    catch
+                    {
+                        return new byte[0];
+                    }
+                }
+
                 return ms.ToArray();
             }
         }
@@ -125,7 +154,15 @@ namespace OutSystems.NssAdvanced_Excel
         {
             try
             {
-                return Color.FromArgb(Int32.Parse(colorCode.Replace("#", ""), NumberStyles.HexNumber));
+                string hex = colorCode.Replace("#", "");
+                int argb = unchecked((int)long.Parse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture));
+
+                if (hex.Length <= 6)
+                {
+                    argb = unchecked((int)((uint)argb | 0xFF000000));
+                }
+
+                return Color.FromArgb(argb);
             }
             catch
             {


### PR DESCRIPTION
## Summary

Three small, self-contained bug fixes in the .NET extension source. **No public API changes** — `Interface.cs` and the generated Structures/Records/RecordLists are untouched, so consuming modules need no changes.

### 1. `NullReferenceException` on empty worksheets
`ExcelWorksheet.Dimension` is `null` for a sheet with no cells. `Row_Delete`, `Column_Delete`, and `Worksheet_AddAutoFilter` dereferenced it directly and threw `NullReferenceException`. Guarded all three — the delete actions still run; `AddAutoFilter` returns (nothing to filter).

### 2. Cell fill/font colours written transparent
`Util.ConvertFromColorCode` parsed a 6-digit `#RRGGBB` with `Int32.Parse`, leaving alpha = `0` (fully transparent) and producing a malformed 6-digit ARGB. Now parses as `long` and forces opaque alpha when no alpha channel is supplied (`#FF0000` → `FFFF0000`).

### 3. `Worksheet_GetImages` crash
`Util.ImageToByteArray` read `Image.RawFormat`, which throws *"Parameter is not valid"* for pictures EPPlus rehydrates from a workbook, breaking `Worksheet_GetImages`. Now defaults to PNG, uses `RawFormat` only when readable/encodable, and falls back safely instead of throwing.
