### PR TITLE
Fix GetBinaryData hiding visible rows on zeroHeight worksheets

### DIFF
--- a/Advanced_Excel/Source/NET/Advanced_Excel.cs
+++ b/Advanced_Excel/Source/NET/Advanced_Excel.cs
@@ -229,6 +229,7 @@ namespace OutSystems.NssAdvanced_Excel
                 worksheet.View.RightToLeft = true;
             }
 
+            Util.PreserveVisibleRowsForZeroHeightSheets(p);
             ssBinaryData = p.GetAsByteArray();
             // GetAsByteArray closes the package; reload so the workbook stays usable.
             p.Load(new System.IO.MemoryStream(ssBinaryData));
@@ -2412,6 +2413,7 @@ namespace OutSystems.NssAdvanced_Excel
         public void MssWorkbook_GetBinaryData(object ssWorkbook, out byte[] ssBinaryData)
         {
             ExcelPackage p = ssWorkbook as ExcelPackage;
+            Util.PreserveVisibleRowsForZeroHeightSheets(p);
             ssBinaryData = p.GetAsByteArray();
             // GetAsByteArray closes the package; reload so the workbook stays usable.
             p.Load(new System.IO.MemoryStream(ssBinaryData));

--- a/Advanced_Excel/Source/NET/Util.cs
+++ b/Advanced_Excel/Source/NET/Util.cs
@@ -190,6 +190,67 @@ namespace OutSystems.NssAdvanced_Excel
         }
 
         /// <summary>
+        /// Worksheets saved with sheetFormatPr/@zeroHeight="1" hide every row by default and rely on
+        /// explicit row records to mark the visible ones. EPPlus's save prunes empty row records, which
+        /// turns those visible blank rows hidden (content ends up squashed). For such sheets, pin a real
+        /// record on each visible row in the used range so it survives the save. Other sheets are untouched.
+        /// </summary>
+        internal static void PreserveVisibleRowsForZeroHeightSheets(ExcelPackage package)
+        {
+            if (package == null)
+            {
+                return;
+            }
+
+            foreach (var ws in package.Workbook.Worksheets)
+            {
+                if (ws.Dimension == null || !WorksheetUsesZeroHeight(ws))
+                {
+                    continue;
+                }
+
+                int end = ws.Dimension.End.Row;
+                for (int r = 1; r <= end; r++)
+                {
+                    if (!ws.Row(r).Hidden)
+                    {
+                        ws.Row(r).CustomHeight = true;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// True when the worksheet's sheetFormatPr has zeroHeight set (all rows hidden by default).
+        /// </summary>
+        private static bool WorksheetUsesZeroHeight(ExcelWorksheet ws)
+        {
+            try
+            {
+                var xml = ws.WorksheetXml;
+                if (xml == null || xml.DocumentElement == null)
+                {
+                    return false;
+                }
+
+                var nsmgr = new System.Xml.XmlNamespaceManager(xml.NameTable);
+                nsmgr.AddNamespace("d", xml.DocumentElement.NamespaceURI);
+                var node = xml.SelectSingleNode("//d:sheetFormatPr", nsmgr) as System.Xml.XmlElement;
+                if (node == null)
+                {
+                    return false;
+                }
+
+                string z = node.GetAttribute("zeroHeight");
+                return z == "1" || string.Equals(z, "true", System.StringComparison.OrdinalIgnoreCase);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Apply the specified format to a range of cells
         /// </summary>
         /// <param name="range">The range of cells to apply the formatting to</param>


### PR DESCRIPTION
## Problem

Reported on the forum (discussion 102555). When a workbook contains a worksheet saved with `sheetFormatPr/@zeroHeight="1"` — meaning "all rows are hidden by default" — calling `Workbook_GetBinaryData` (or `SaveRightToLeft`) collapses the previously-visible rows and squashes the content.

## Cause

On a `zeroHeight` sheet, the visible rows exist only because Excel writes an explicit `<row>` record for each one. EPPlus's `GetAsByteArray()` prunes empty `<row>` records on save. With `zeroHeight="1"`, every row without a record falls back to zero height — i.e. hidden — so the rows that were visible blank rows disappear.

## Fix

Before saving in `GetBinaryData` and `SaveRightToLeft`, detect `zeroHeight` worksheets (via `sheetFormatPr/@zeroHeight`) and pin a real row record (`CustomHeight = true`) on every visible row in the used range, so those rows survive the save. Sheets that don't use `zeroHeight` are left completely untouched.

## Verification

Reproduced with the file from the forum thread: the source sheet has 49 visible rows; before the fix the round-trip collapsed it to 13, after the fix all 49 survive. A regression test opens the real file, round-trips it through `GetBinaryData`, and asserts the visible-row count is preserved.