### PR TITLE
Read conditional-formatting rule style back in GetAllRules

### DIFF
--- a/Advanced_Excel/Source/NET/Advanced_Excel.cs
+++ b/Advanced_Excel/Source/NET/Advanced_Excel.cs
@@ -1801,6 +1801,21 @@ namespace OutSystems.NssAdvanced_Excel
                         break;
                 }
 
+                // Read the rule's differential style back (skip the rule types that don't use one).
+                switch (item.Type)
+                {
+                    case eExcelConditionalFormattingRuleType.TwoColorScale:
+                    case eExcelConditionalFormattingRuleType.ThreeColorScale:
+                    case eExcelConditionalFormattingRuleType.ThreeIconSet:
+                    case eExcelConditionalFormattingRuleType.FourIconSet:
+                    case eExcelConditionalFormattingRuleType.FiveIconSet:
+                    case eExcelConditionalFormattingRuleType.DataBar:
+                        break;
+                    default:
+                        newItem.ssSTConditionalFormatItem.ssStyle = Util.ReadConditionalFormattingStyle(item.Style);
+                        break;
+                }
+
                 ssListOfRule.Add(newItem);
             }
 

--- a/Advanced_Excel/Source/NET/Util.cs
+++ b/Advanced_Excel/Source/NET/Util.cs
@@ -456,6 +456,76 @@ namespace OutSystems.NssAdvanced_Excel
         }
 
         /// <summary>
+        /// Read a conditional-formatting rule's differential style (fill, font, borders, number
+        /// format) back into a record. Mirror of <see cref="ApplyConditionalFormattingStyle"/> so
+        /// GetAllRules returns the rule's actual style instead of defaults.
+        /// </summary>
+        internal static RCConditionalFormatStyleRecord ReadConditionalFormattingStyle(ExcelDxfStyleConditionalFormatting style)
+        {
+            var rec = new RCConditionalFormatStyleRecord(null);
+            if (style == null)
+            {
+                return rec;
+            }
+
+            // Fill
+            if (style.Fill != null)
+            {
+                if (style.Fill.PatternType.HasValue)
+                {
+                    rec.ssSTConditionalFormatStyle.ssFill.ssSTFillStyle.ssPatternType = (int)style.Fill.PatternType.Value;
+                }
+                if (style.Fill.BackgroundColor != null && style.Fill.BackgroundColor.Color.HasValue)
+                {
+                    rec.ssSTConditionalFormatStyle.ssFill.ssSTFillStyle.ssBackgroundColor = ToHexRgb(style.Fill.BackgroundColor.Color.Value);
+                }
+                if (style.Fill.PatternColor != null && style.Fill.PatternColor.Color.HasValue)
+                {
+                    rec.ssSTConditionalFormatStyle.ssFill.ssSTFillStyle.ssPatternColor = ToHexRgb(style.Fill.PatternColor.Color.Value);
+                }
+            }
+
+            // Font
+            if (style.Font != null)
+            {
+                if (style.Font.Bold.HasValue) rec.ssSTConditionalFormatStyle.ssFont.ssSTFontStyle.ssBold = style.Font.Bold.Value;
+                if (style.Font.Italic.HasValue) rec.ssSTConditionalFormatStyle.ssFont.ssSTFontStyle.ssItalic = style.Font.Italic.Value;
+                if (style.Font.Strike.HasValue) rec.ssSTConditionalFormatStyle.ssFont.ssSTFontStyle.ssStrike = style.Font.Strike.Value;
+                if (style.Font.Underline.HasValue) rec.ssSTConditionalFormatStyle.ssFont.ssSTFontStyle.ssUnderline = (int)style.Font.Underline.Value;
+                if (style.Font.Color != null && style.Font.Color.Color.HasValue) rec.ssSTConditionalFormatStyle.ssFont.ssSTFontStyle.ssColor = ToHexRgb(style.Font.Color.Color.Value);
+            }
+
+            // Borders
+            if (style.Border != null)
+            {
+                if (style.Border.Top.Style.HasValue) rec.ssSTConditionalFormatStyle.ssBorderTop.ssSTBorderStyle.ssStyle = (int)style.Border.Top.Style.Value;
+                if (style.Border.Top.Color != null && style.Border.Top.Color.Color.HasValue) rec.ssSTConditionalFormatStyle.ssBorderTop.ssSTBorderStyle.ssColor = ToHexRgb(style.Border.Top.Color.Color.Value);
+
+                if (style.Border.Bottom.Style.HasValue) rec.ssSTConditionalFormatStyle.ssBorderBottom.ssSTBorderStyle.ssStyle = (int)style.Border.Bottom.Style.Value;
+                if (style.Border.Bottom.Color != null && style.Border.Bottom.Color.Color.HasValue) rec.ssSTConditionalFormatStyle.ssBorderBottom.ssSTBorderStyle.ssColor = ToHexRgb(style.Border.Bottom.Color.Color.Value);
+
+                if (style.Border.Left.Style.HasValue) rec.ssSTConditionalFormatStyle.ssBorderLeft.ssSTBorderStyle.ssStyle = (int)style.Border.Left.Style.Value;
+                if (style.Border.Left.Color != null && style.Border.Left.Color.Color.HasValue) rec.ssSTConditionalFormatStyle.ssBorderLeft.ssSTBorderStyle.ssColor = ToHexRgb(style.Border.Left.Color.Color.Value);
+
+                if (style.Border.Right.Style.HasValue) rec.ssSTConditionalFormatStyle.ssBorderRight.ssSTBorderStyle.ssStyle = (int)style.Border.Right.Style.Value;
+                if (style.Border.Right.Color != null && style.Border.Right.Color.Color.HasValue) rec.ssSTConditionalFormatStyle.ssBorderRight.ssSTBorderStyle.ssColor = ToHexRgb(style.Border.Right.Color.Color.Value);
+            }
+
+            // Number format
+            if (style.NumberFormat != null && !string.IsNullOrEmpty(style.NumberFormat.Format))
+            {
+                rec.ssSTConditionalFormatStyle.ssNumberFormat = style.NumberFormat.Format;
+            }
+
+            return rec;
+        }
+
+        private static string ToHexRgb(System.Drawing.Color c)
+        {
+            return "#" + c.R.ToString("X2") + c.G.ToString("X2") + c.B.ToString("X2");
+        }
+
+        /// <summary>
         /// 
         /// </summary>
         /// <param name="dimension"></param>


### PR DESCRIPTION
## Problem

`ConditionalFormatting_GetAllRules` returned each rule's `Style` as all-default values — it read the address, type, formula, colour-scale colours and icon-set settings, but never read the rule's differential style (fill/font/border). This made it impossible to inspect a rule's actual formatting and was a misleading way to verify that a format had been applied.

## Fix

`GetAllRules` now reads the rule's differential style back into the returned record:
- **Fill**: pattern type, background colour, pattern colour
- **Font**: bold, italic, strike, underline, colour
- **Borders**: top/bottom/left/right style + colour
- **Number format**

Colour-scale, icon-set and data-bar rules don't use a differential style and are skipped.

Body-only change (no new actions or structures). Verified with a round-trip test: add an Expression rule with a solid fill, call `GetAllRules`, and the returned style reports `PatternType=Solid` / `BackgroundColor=#FF0000` instead of defaults.