### PR TITLE
Fix conditional formatting forcing an underline when set to none

### DIFF
--- a/Advanced_Excel/Source/NET/Util.cs
+++ b/Advanced_Excel/Source/NET/Util.cs
@@ -529,7 +529,14 @@ namespace OutSystems.NssAdvanced_Excel
                 style.Font.Strike = null;
             }
 
-            style.Font.Underline = underline;
+            if (underline != ExcelUnderLineType.None)
+            {
+                style.Font.Underline = underline;
+            }
+            else
+            {
+                style.Font.Underline = null;
+            }
 
             if (!string.IsNullOrEmpty(ssStyle.ssSTConditionalFormatStyle.ssFont.ssSTFontStyle.ssColor))
             {


### PR DESCRIPTION
Reported on the forum (discussion 106689): a conditional-formatting rule set yellow background and red text correctly, but always underlined the text — even with the font underline parameter explicitly set to 0.

## Cause

With the underline set to 0, the rule's differential format was still written with an underline entry:

```xml
<font><b val="0" /><i val="0" /><u val="None" /><color rgb="ffff0000" /></font>
```

`None` is not a valid `ST_UnderlineValues` token (the schema's values are lowercase). Excel falls back to the `<u>` element's default, which is a single underline — so asking for no underline produced one.

## Fix

No underline entry is written unless one is requested, matching how the neighbouring strikethrough option already behaves. Requesting an underline still works.

```xml
<font><b val="0" /><i val="0" /><color rgb="ffff0000" /></font>
```