### PR TITLE
Add Worksheet_SortRange action

### DIFF
--- a/Advanced_Excel/Source/NET/Advanced_Excel.cs
+++ b/Advanced_Excel/Source/NET/Advanced_Excel.cs
@@ -20,6 +20,52 @@ namespace OutSystems.NssAdvanced_Excel
     {
 
 		/// <summary>
+		/// Sorts the rows of a range by one or more columns. Cell values and formatting move together with their row.
+		/// </summary>
+		/// <param name="ssWorksheet">The worksheet to work with.</param>
+		/// <param name="ssRange">A1 range, e.g. A1:D100.</param>
+		/// <param name="ssHasHeader">Keeps the first row in place instead of sorting it into the data.</param>
+		/// <param name="ssSortFields">Applied in order (first field is the primary sort).</param>
+		public void MssWorksheet_SortRange(object ssWorksheet, string ssRange, bool ssHasHeader, RLSortFieldRecordList ssSortFields) {
+			ExcelWorksheet ws = AsWorksheet(ssWorksheet);
+
+			if (string.IsNullOrEmpty(ssRange))
+			{
+				throw new ArgumentException("Range is required.", nameof(ssRange));
+			}
+			if (ssSortFields == null || ssSortFields.Count == 0)
+			{
+				throw new ArgumentException("At least one sort field is required.", nameof(ssSortFields));
+			}
+
+			ExcelAddress address = new ExcelAddress(ssRange);
+			int startRow = ssHasHeader ? address.Start.Row + 1 : address.Start.Row;
+			if (startRow > address.End.Row)
+			{
+				return;
+			}
+
+			int width = address.End.Column - address.Start.Column + 1;
+			var columns = new int[ssSortFields.Count];
+			var descending = new bool[ssSortFields.Count];
+
+			for (int i = 0; i < ssSortFields.Count; i++)
+			{
+				var field = ssSortFields[i].ssSTSortField;
+				if (field.ssColumn < 1 || field.ssColumn > width)
+				{
+					throw new ArgumentException("Sort column " + field.ssColumn + " is outside the range " + ssRange + ", which is " + width + " column(s) wide. Columns are counted from the left of the range starting at 1.", nameof(ssSortFields));
+				}
+				// the extension counts range columns from 1; EPPlus expects a 0-based offset
+				columns[i] = field.ssColumn - 1;
+				descending[i] = field.ssDescending;
+			}
+
+			ws.Cells[startRow, address.Start.Column, address.End.Row, address.End.Column]
+			  .Sort(columns, descending, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.CompareOptions.None);
+		} // MssWorksheet_SortRange
+
+		/// <summary>
 		/// Saves the workbook as an AES-encrypted, password-protected .xlsx. The password is required to open the file in Excel.
 		/// </summary>
 		/// <param name="ssWorkbook">The workbook to save.</param>

--- a/Advanced_Excel/Source/NET/Interface.cs
+++ b/Advanced_Excel/Source/NET/Interface.cs
@@ -1206,6 +1206,15 @@ namespace OutSystems.NssAdvanced_Excel {
 		/// <param name="ssBinaryData">The encrypted .xlsx file</param>
 		void MssWorkbook_SaveWithPassword(object ssWorkbook, string ssPassword, out byte[] ssBinaryData);
 
+		/// <summary>
+		/// Sorts the rows of a range by one or more columns. Cell values and formatting move together with their row.
+		/// </summary>
+		/// <param name="ssWorksheet">The worksheet to work with.</param>
+		/// <param name="ssRange">A1 range, e.g. A1:D100.</param>
+		/// <param name="ssHasHeader">Keeps the first row in place instead of sorting it into the data.</param>
+		/// <param name="ssSortFields">Applied in order (first field is the primary sort).</param>
+		void MssWorksheet_SortRange(object ssWorksheet, string ssRange, bool ssHasHeader, RLSortFieldRecordList ssSortFields);
+
 	} // IssAdvanced_Excel
 
 } // OutSystems.NssAdvanced_Excel

--- a/Advanced_Excel/Source/NET/RecordLists.cs
+++ b/Advanced_Excel/Source/NET/RecordLists.cs
@@ -1855,4 +1855,88 @@ namespace OutSystems.NssAdvanced_Excel {
 
 
 	} // RLPivotFieldRecordList
+
+	/// <summary>
+	/// RecordList type <code>RLSortFieldRecordList</code> that represents a record list of
+	///  <code>SortField</code>
+	/// </summary>
+	[Serializable()]
+	public partial class RLSortFieldRecordList: GenericRecordList<RCSortFieldRecord>, IEnumerable, IEnumerator, ISerializable {
+		public static void EnsureInitialized() {}
+
+		protected override RCSortFieldRecord GetElementDefaultValue() {
+			return new RCSortFieldRecord("");
+		}
+
+		public T[] ToArray<T>(Func<RCSortFieldRecord, T> converter) {
+			return ToArray(this, converter);
+		}
+
+		public static T[] ToArray<T>(RLSortFieldRecordList recordlist, Func<RCSortFieldRecord, T> converter) {
+			return InnerToArray(recordlist, converter);
+		}
+		public static implicit operator RLSortFieldRecordList(RCSortFieldRecord[] array) {
+			RLSortFieldRecordList result = new RLSortFieldRecordList();
+			result.InnerFromArray(array);
+			return result;
+		}
+
+		public static RLSortFieldRecordList ToList<T>(T[] array, Func <T, RCSortFieldRecord> converter) {
+			RLSortFieldRecordList result = new RLSortFieldRecordList();
+			result.InnerFromArray(array, converter);
+			return result;
+		}
+
+		public static RLSortFieldRecordList FromRestList<T>(RestList<T> restList, Func <T, RCSortFieldRecord> converter) {
+			RLSortFieldRecordList result = new RLSortFieldRecordList();
+			result.InnerFromRestList(restList, converter);
+			return result;
+		}
+		/// <summary>
+		/// Default Constructor
+		/// </summary>
+		public RLSortFieldRecordList(): base() {
+		}
+
+		/// <summary>
+		/// Constructor with transaction parameter
+		/// </summary>
+		/// <param name="trans"> IDbTransaction Parameter</param>
+		[Obsolete("Use the Default Constructor and set the Transaction afterwards.")]
+		public RLSortFieldRecordList(IDbTransaction trans): base(trans) {
+		}
+
+		/// <summary>
+		/// Constructor with transaction parameter and alternate read method
+		/// </summary>
+		/// <param name="trans"> IDbTransaction Parameter</param>
+		/// <param name="alternateReadDBMethod"> Alternate Read Method</param>
+		[Obsolete("Use the Default Constructor and set the Transaction afterwards.")]
+		public RLSortFieldRecordList(IDbTransaction trans, ReadDBMethodDelegate alternateReadDBMethod): this(trans) {
+			this.alternateReadDBMethod = alternateReadDBMethod;
+		}
+
+		/// <summary>
+		/// Constructor declaration for serialization
+		/// </summary>
+		/// <param name="info"> SerializationInfo</param>
+		/// <param name="context"> StreamingContext</param>
+		public RLSortFieldRecordList(SerializationInfo info, StreamingContext context): base(info, context) {
+		}
+
+		public override BitArray[] GetDefaultOptimizedValues() {
+			BitArray[] def = new BitArray[1];
+			def[0] = null;
+			return def;
+		}
+		/// <summary>
+		/// Create as new list
+		/// </summary>
+		/// <returns>The new record list</returns>
+		protected override OSList<RCSortFieldRecord> NewList() {
+			return new RLSortFieldRecordList();
+		}
+
+
+	} // RLSortFieldRecordList
 }

--- a/Advanced_Excel/Source/NET/Records.cs
+++ b/Advanced_Excel/Source/NET/Records.cs
@@ -4213,4 +4213,195 @@ namespace OutSystems.NssAdvanced_Excel {
 			return true;
 		}
 	} // RCPivotFieldRecord
+
+	/// <summary>
+	/// Structure <code>RCSortFieldRecord</code>
+	/// </summary>
+	[Serializable()]
+	public partial struct RCSortFieldRecord: ISerializable, ITypedRecord<RCSortFieldRecord> {
+		internal static readonly GlobalObjectKey IdSortField = GlobalObjectKey.Parse("2UmDmepsh0WSfJ_D1JexCA*BxTvSacv4sVNfQOEvF8K6A");
+
+		public static void EnsureInitialized() {}
+		[System.Xml.Serialization.XmlElement("SortField")]
+		public STSortFieldStructure ssSTSortField;
+
+
+		public static implicit operator STSortFieldStructure(RCSortFieldRecord r) {
+			return r.ssSTSortField;
+		}
+
+		public static implicit operator RCSortFieldRecord(STSortFieldStructure r) {
+			RCSortFieldRecord res = new RCSortFieldRecord(null);
+			res.ssSTSortField = r;
+			return res;
+		}
+
+		public BitArray OptimizedAttributes;
+
+		public RCSortFieldRecord(params string[] dummy) {
+			OptimizedAttributes = null;
+			ssSTSortField = new STSortFieldStructure(null);
+		}
+
+		public BitArray[] GetDefaultOptimizedValues() {
+			BitArray[] all = new BitArray[1];
+			all[0] = null;
+			return all;
+		}
+
+		public BitArray[] AllOptimizedAttributes {
+			set {
+				if (value == null) {
+				} else {
+					ssSTSortField.OptimizedAttributes = value[0];
+				}
+			}
+			get {
+				BitArray[] all = new BitArray[1];
+				all[0] = null;
+				return all;
+			}
+		}
+
+		/// <summary>
+		/// Read a record from database
+		/// </summary>
+		/// <param name="r"> Data base reader</param>
+		/// <param name="index"> index</param>
+		public void Read(IDataReader r, ref int index) {
+			ssSTSortField.Read(r, ref index);
+		}
+		/// <summary>
+		/// Read from database
+		/// </summary>
+		/// <param name="r"> Data reader</param>
+		public void ReadDB(IDataReader r) {
+			int index = 0;
+			Read(r, ref index);
+		}
+
+		/// <summary>
+		/// Read from record
+		/// </summary>
+		/// <param name="r"> Record</param>
+		public void ReadIM(RCSortFieldRecord r) {
+			this = r;
+		}
+
+
+		public static bool operator == (RCSortFieldRecord a, RCSortFieldRecord b) {
+			if (a.ssSTSortField != b.ssSTSortField) return false;
+			return true;
+		}
+
+		public static bool operator != (RCSortFieldRecord a, RCSortFieldRecord b) {
+			return !(a==b);
+		}
+
+		public override bool Equals(object o) {
+			if (o.GetType() != typeof(RCSortFieldRecord)) return false;
+			return (this == (RCSortFieldRecord) o);
+		}
+
+		public override int GetHashCode() {
+			try {
+				return base.GetHashCode()
+				^ ssSTSortField.GetHashCode()
+				;
+			} catch {
+				return base.GetHashCode();
+			}
+		}
+
+		public void GetObjectData(SerializationInfo info, StreamingContext context) {
+			Type objInfo = this.GetType();
+			FieldInfo[] fields;
+			fields = objInfo.GetFields(BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public);
+			for (int i = 0; i < fields.Length; i++)
+			if (fields[i] .FieldType.IsSerializable)
+			info.AddValue(fields[i] .Name, fields[i] .GetValue(this));
+		}
+
+		public RCSortFieldRecord(SerializationInfo info, StreamingContext context) {
+			OptimizedAttributes = null;
+			ssSTSortField = new STSortFieldStructure(null);
+			Type objInfo = this.GetType();
+			FieldInfo fieldInfo = null;
+			fieldInfo = objInfo.GetField("ssSTSortField", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public);
+			if (fieldInfo == null) {
+				throw new Exception("The field named 'ssSTSortField' was not found.");
+			}
+			if (fieldInfo.FieldType.IsSerializable) {
+				ssSTSortField = (STSortFieldStructure) info.GetValue(fieldInfo.Name, fieldInfo.FieldType);
+			}
+		}
+
+		public void RecursiveReset() {
+			ssSTSortField.RecursiveReset();
+		}
+
+		public void InternalRecursiveSave() {
+			ssSTSortField.InternalRecursiveSave();
+		}
+
+
+		public RCSortFieldRecord Duplicate() {
+			RCSortFieldRecord t;
+			t.ssSTSortField = (STSortFieldStructure) this.ssSTSortField.Duplicate();
+			t.OptimizedAttributes = null;
+			return t;
+		}
+
+		IRecord IRecord.Duplicate() {
+			return Duplicate();
+		}
+
+		public void ToXml(Object parent, System.Xml.XmlElement baseElem, String fieldName, int detailLevel) {
+			System.Xml.XmlElement recordElem = VarValue.AppendChild(baseElem, "Record");
+			if (fieldName != null) {
+				VarValue.AppendAttribute(recordElem, "debug.field", fieldName);
+			}
+			if (detailLevel > 0) {
+				ssSTSortField.ToXml(this, recordElem, "SortField", detailLevel - 1);
+			} else {
+				VarValue.AppendDeferredEvaluationElement(recordElem);
+			}
+		}
+
+		public void EvaluateFields(VarValue variable, Object parent, String baseName, String fields) {
+			String head = VarValue.GetHead(fields);
+			String tail = VarValue.GetTail(fields);
+			variable.Found = false;
+			if (head == "sortfield") {
+				if (!VarValue.FieldIsOptimized(parent, baseName + ".SortField")) variable.Value = ssSTSortField; else variable.Optimized = true;
+				variable.SetFieldName("sortfield");
+			}
+			if (variable.Found && tail != null) variable.EvaluateFields(this, head, tail);
+		}
+
+		public bool ChangedAttributeGet(GlobalObjectKey key) {
+			throw new Exception("Method not Supported");
+		}
+
+		public bool OptimizedAttributeGet(GlobalObjectKey key) {
+			throw new Exception("Method not Supported");
+		}
+
+		public object AttributeGet(GlobalObjectKey key) {
+			if (key == IdSortField) {
+				return ssSTSortField;
+			} else {
+				throw new Exception("Invalid key");
+			}
+		}
+		public void FillFromOther(IRecord other) {
+			if (other == null) return;
+			ssSTSortField.FillFromOther((IRecord) other.AttributeGet(IdSortField));
+		}
+		public bool IsDefault() {
+			RCSortFieldRecord defaultStruct = new RCSortFieldRecord(null);
+			if (this.ssSTSortField != defaultStruct.ssSTSortField) return false;
+			return true;
+		}
+	} // RCSortFieldRecord
 }

--- a/Advanced_Excel/Source/NET/Structures.cs
+++ b/Advanced_Excel/Source/NET/Structures.cs
@@ -6846,4 +6846,207 @@ namespace OutSystems.NssAdvanced_Excel {
 		}
 	} // STPivotFieldStructure
 
+	/// <summary>
+	/// Structure <code>STSortFieldStructure</code> that represents the Service Studio structure
+	///  <code>SortField</code> <p> Description: One column to sort by within Worksheet_SortRange. Column i
+	/// s the 1-based position of the column inside the sorted range, not the worksheet. Descending sorts
+	///  Z→A / high to low.</p>
+	/// </summary>
+	[Serializable()]
+	public partial struct STSortFieldStructure: ISerializable, ITypedRecord<STSortFieldStructure>, ISimpleRecord {
+		internal static readonly GlobalObjectKey IdColumn = GlobalObjectKey.Parse("tQrPfipdPE2fHQ34mD74Uw*WtGEfNT1REe+7ETNO9WvKw");
+		internal static readonly GlobalObjectKey IdDescending = GlobalObjectKey.Parse("tQrPfipdPE2fHQ34mD74Uw*NLcJl8mCT0OPFwq6nkxG3A");
+
+		public static void EnsureInitialized() {}
+		[System.Xml.Serialization.XmlElement("Column")]
+		public int ssColumn;
+
+		[System.Xml.Serialization.XmlElement("Descending")]
+		public bool ssDescending;
+
+
+		public BitArray OptimizedAttributes;
+
+		public STSortFieldStructure(params string[] dummy) {
+			OptimizedAttributes = null;
+			ssColumn = 0;
+			ssDescending = false;
+		}
+
+		public BitArray[] GetDefaultOptimizedValues() {
+			BitArray[] all = new BitArray[0];
+			return all;
+		}
+
+		public BitArray[] AllOptimizedAttributes {
+			set {
+				if (value == null) {
+				} else {
+				}
+			}
+			get {
+				BitArray[] all = new BitArray[0];
+				return all;
+			}
+		}
+
+		/// <summary>
+		/// Read a record from database
+		/// </summary>
+		/// <param name="r"> Data base reader</param>
+		/// <param name="index"> index</param>
+		public void Read(IDataReader r, ref int index) {
+			ssColumn = r.ReadInteger(index++, "SortField.Column", 0);
+			ssDescending = r.ReadBoolean(index++, "SortField.Descending", false);
+		}
+		/// <summary>
+		/// Read from database
+		/// </summary>
+		/// <param name="r"> Data reader</param>
+		public void ReadDB(IDataReader r) {
+			int index = 0;
+			Read(r, ref index);
+		}
+
+		/// <summary>
+		/// Read from record
+		/// </summary>
+		/// <param name="r"> Record</param>
+		public void ReadIM(STSortFieldStructure r) {
+			this = r;
+		}
+
+
+		public static bool operator == (STSortFieldStructure a, STSortFieldStructure b) {
+			if (a.ssColumn != b.ssColumn) return false;
+			if (a.ssDescending != b.ssDescending) return false;
+			return true;
+		}
+
+		public static bool operator != (STSortFieldStructure a, STSortFieldStructure b) {
+			return !(a==b);
+		}
+
+		public override bool Equals(object o) {
+			if (o.GetType() != typeof(STSortFieldStructure)) return false;
+			return (this == (STSortFieldStructure) o);
+		}
+
+		public override int GetHashCode() {
+			try {
+				return base.GetHashCode()
+				^ ssColumn.GetHashCode()
+				^ ssDescending.GetHashCode()
+				;
+			} catch {
+				return base.GetHashCode();
+			}
+		}
+
+		public void GetObjectData(SerializationInfo info, StreamingContext context) {
+			Type objInfo = this.GetType();
+			FieldInfo[] fields;
+			fields = objInfo.GetFields(BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public);
+			for (int i = 0; i < fields.Length; i++)
+			if (fields[i] .FieldType.IsSerializable)
+			info.AddValue(fields[i] .Name, fields[i] .GetValue(this));
+		}
+
+		public STSortFieldStructure(SerializationInfo info, StreamingContext context) {
+			OptimizedAttributes = null;
+			ssColumn = 0;
+			ssDescending = false;
+			Type objInfo = this.GetType();
+			FieldInfo fieldInfo = null;
+			fieldInfo = objInfo.GetField("ssColumn", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public);
+			if (fieldInfo == null) {
+				throw new Exception("The field named 'ssColumn' was not found.");
+			}
+			if (fieldInfo.FieldType.IsSerializable) {
+				ssColumn = (int) info.GetValue(fieldInfo.Name, fieldInfo.FieldType);
+			}
+			fieldInfo = objInfo.GetField("ssDescending", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public);
+			if (fieldInfo == null) {
+				throw new Exception("The field named 'ssDescending' was not found.");
+			}
+			if (fieldInfo.FieldType.IsSerializable) {
+				ssDescending = (bool) info.GetValue(fieldInfo.Name, fieldInfo.FieldType);
+			}
+		}
+
+		public void RecursiveReset() {
+		}
+
+		public void InternalRecursiveSave() {
+		}
+
+
+		public STSortFieldStructure Duplicate() {
+			STSortFieldStructure t;
+			t.ssColumn = this.ssColumn;
+			t.ssDescending = this.ssDescending;
+			t.OptimizedAttributes = null;
+			return t;
+		}
+
+		IRecord IRecord.Duplicate() {
+			return Duplicate();
+		}
+
+		public void ToXml(Object parent, System.Xml.XmlElement baseElem, String fieldName, int detailLevel) {
+			System.Xml.XmlElement recordElem = VarValue.AppendChild(baseElem, "Structure");
+			if (fieldName != null) {
+				VarValue.AppendAttribute(recordElem, "debug.field", fieldName);
+				fieldName = fieldName.ToLowerInvariant();
+			}
+			if (detailLevel > 0) {
+				if (!VarValue.FieldIsOptimized(parent, fieldName + ".Column")) VarValue.AppendAttribute(recordElem, "Column", ssColumn, detailLevel, TypeKind.Integer); else VarValue.AppendOptimizedAttribute(recordElem, "Column");
+				if (!VarValue.FieldIsOptimized(parent, fieldName + ".Descending")) VarValue.AppendAttribute(recordElem, "Descending", ssDescending, detailLevel, TypeKind.Boolean); else VarValue.AppendOptimizedAttribute(recordElem, "Descending");
+			} else {
+				VarValue.AppendDeferredEvaluationElement(recordElem);
+			}
+		}
+
+		public void EvaluateFields(VarValue variable, Object parent, String baseName, String fields) {
+			String head = VarValue.GetHead(fields);
+			String tail = VarValue.GetTail(fields);
+			variable.Found = false;
+			if (head == "column") {
+				if (!VarValue.FieldIsOptimized(parent, baseName + ".Column")) variable.Value = ssColumn; else variable.Optimized = true;
+			} else if (head == "descending") {
+				if (!VarValue.FieldIsOptimized(parent, baseName + ".Descending")) variable.Value = ssDescending; else variable.Optimized = true;
+			}
+			if (variable.Found && tail != null) variable.EvaluateFields(this, head, tail);
+		}
+
+		public bool ChangedAttributeGet(GlobalObjectKey key) {
+			throw new Exception("Method not Supported");
+		}
+
+		public bool OptimizedAttributeGet(GlobalObjectKey key) {
+			throw new Exception("Method not Supported");
+		}
+
+		public object AttributeGet(GlobalObjectKey key) {
+			if (key == IdColumn) {
+				return ssColumn;
+			} else if (key == IdDescending) {
+				return ssDescending;
+			} else {
+				throw new Exception("Invalid key");
+			}
+		}
+		public void FillFromOther(IRecord other) {
+			if (other == null) return;
+			ssColumn = (int) other.AttributeGet(IdColumn);
+			ssDescending = (bool) other.AttributeGet(IdDescending);
+		}
+		public bool IsDefault() {
+			STSortFieldStructure defaultStruct = new STSortFieldStructure(null);
+			if (this.ssColumn != defaultStruct.ssColumn) return false;
+			if (this.ssDescending != defaultStruct.ssDescending) return false;
+			return true;
+		}
+	} // STSortFieldStructure
+
 } // OutSystems.NssAdvanced_Excel


### PR DESCRIPTION
Requested on the forum (discussion 106865): sorting a range inside the spreadsheet, rather than having to sort the data before writing it.

## `Worksheet_SortRange`

Sorts the rows of a range by one or more columns. Each sort field is a **SortField** (new structure): `Column`, counted from the left of the sorted range starting at 1, and `Descending`. Fields are applied in order, so the first is the primary sort.

- `HasHeader` keeps the first row of the range in place. Without it, sorting a range that includes its header row shuffles the header in with the data.
- Cell values and formatting move together with their row.
- Sorting uses the invariant culture, so results don't depend on the server locale.
- A sort column outside the range, or an empty field list, raises a clear error.